### PR TITLE
fix(sec): upgrade shiro-core to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,7 @@
 		<jersey.version>2.37</jersey.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
 		<lucene.version>8.7.0</lucene.version>
-		<shiro.version>1.7.1</shiro.version>
+		<shiro.version>1.8.0</shiro.version>
 		<jgit.version>5.13.0.202109080827-r</jgit.version>
 		<flexmark.version>0.62.2</flexmark.version>
 		<groovy.version>3.0.10</groovy.version>


### PR DESCRIPTION
Upgrade upgrade from1.7.1 to1.8.0 for vulnerability fix:
- [CVE-2021-41303](https://www.oscs1024.com/hd/MPS-2021-32074)