### PR TITLE
Check the collection is not empty before call iterator().next()

### DIFF
--- a/server-core/src/main/java/io/onedev/server/buildspec/job/log/instruction/SetBuildVersion.java
+++ b/server-core/src/main/java/io/onedev/server/buildspec/job/log/instruction/SetBuildVersion.java
@@ -32,7 +32,13 @@ public class SetBuildVersion extends LogInstruction {
 	@Transactional
 	@Override
 	public void execute(Build build, Map<String, List<String>> params, TaskLogger taskLogger) {
-		String version = params.values().iterator().next().iterator().next();
+		String version = null;
+		if (!params.isEmpty()) {
+			List<String> values = params.values().iterator().next();
+			if (!values.isEmpty()) {
+				version = values.iterator().next();
+			}
+		}
 		if (StringUtils.isNotBlank(version))
 			build.setVersion(version);
 		else


### PR DESCRIPTION
The 'params' parameter in the 'execute' method of the 'SetBuildVersion' class is constructed in the 'newLogger' method of the 'DefaultLogManager' class. 
However, it appears that there is no guarantee that 'params' or 'paramValues' are not empty during the construction process.

```
// DefaultLogManager.newLogger
Map<String, List<String>> params = new HashMap<>();
for (ParamContext paramContext: instructionContext.param()) {
        String paramName;
        if (paramContext.Identifier() != null)
	        paramName = paramContext.Identifier().getText();
        else
	       paramName = "";
        List<String> paramValues = new ArrayList<>();
        for (TerminalNode terminalNode: paramContext.Value())
	       paramValues.add(LogInstruction.getValue(terminalNode));
        params.put(paramName, paramValues);
}
doInSession(instruction, buildId, params, this);
```